### PR TITLE
Util functions working with SEXP of Basic and VecBasic

### DIFF
--- a/R/vector.R
+++ b/R/vector.R
@@ -14,17 +14,17 @@ vecbasic <- function(...) {
         else
             return(S(x))
     })
-    new("VecBasic", .vecbasic(lt))
+    .vecbasic(lt)
 }
 
 vecbasic_subset <- function(vec, idx) {
     # idx can only be integer vector
-    new("VecBasic", .vecbasic_subset(vec, idx));
+    .vecbasic_subset(vec, idx)
 }
 
 vecbasic_get <- function(vec, n) {
     # n can only be integer
-    new("Basic", .vecbasic_get(vec, n))
+    .vecbasic_get(vec, n)
 }
 
 setMethods("c", list(c(x = "VecBasic"), c(x = "Basic")),

--- a/R/vector.R
+++ b/R/vector.R
@@ -10,21 +10,21 @@ vecbasic <- function(...) {
     # C-level function for conversion to basic to reduce overhead.
     lt <- lapply(unname(list(...)), function(x) {
         if (is(x, "Basic") || is(x, "VecBasic"))
-            return(x@.xData)
+            return(x)
         else
-            return(S(x)@.xData)
+            return(S(x))
     })
     new("VecBasic", .vecbasic(lt))
 }
 
 vecbasic_subset <- function(vec, idx) {
     # idx can only be integer vector
-    new("VecBasic", .vecbasic_subset(vec@.xData, idx));
+    new("VecBasic", .vecbasic_subset(vec, idx));
 }
 
 vecbasic_get <- function(vec, n) {
     # n can only be integer
-    new("Basic", .vecbasic_get(vec@.xData, n))
+    new("Basic", .vecbasic_get(vec, n))
 }
 
 setMethods("c", list(c(x = "VecBasic"), c(x = "Basic")),
@@ -35,7 +35,7 @@ setMethods("c", list(c(x = "VecBasic"), c(x = "Basic")),
 
 setMethod("length", "VecBasic",
     function(x) {
-        .vecbasic_length(x@.xData)
+        .vecbasic_length(x)
     }
 )
 

--- a/src/basic_opts.cpp
+++ b/src/basic_opts.cpp
@@ -41,8 +41,6 @@ SEXP sexp_basic_pow(SEXP exta, SEXP extb) {return call_twoarg_opt(basic_pow, ext
 SEXP sexp_basic_diff(SEXP exta, SEXP extb) {return call_twoarg_opt(basic_diff, exta, extb);}
 
 
-// Here we also do conversion from S4 to externalptr, and initialization of the output
-// S4 object. In other functions, they are done in the R level.
 static inline
 SEXP wrap_basic_func_onearg(SEXP exta,
                             CWRAPPER_OUTPUT_TYPE (* func)(basic, const basic)) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -114,7 +114,7 @@ basic_struct* elt_basic(SEXP x) {
     }
     
     if (NULL == out)
-        Rf_error("Invalid pointer");
+        Rf_error("Invalid pointer for 'Basic'");
     
     return out;
 }
@@ -140,7 +140,7 @@ CVecBasic* elt_vecbasic(SEXP x) {
     }
     
     if (NULL == out)
-        Rf_error("Invalid pointer");
+        Rf_error("Invalid pointer for 'VecBasic'");
     
     return out;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -38,7 +38,7 @@ SEXP sexp_basic_s4() {
 
 static inline
 SEXP sexp_vecbasic_s4() {
-    SEXP empty = PROTECT(R_do_new_object(R_getClassDef("Basic")));
+    SEXP empty = PROTECT(R_do_new_object(R_getClassDef("VecBasic")));
     SEXP out   = PROTECT(R_do_slot_assign(empty, Rf_mkString(".xData"), sexp_vecbasic()));
     UNPROTECT(2);
     return out;

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -20,7 +20,7 @@ static inline void _vecbasic_append_sexp(CVecBasic* self, SEXP ext);
 
 // [[Rcpp::export(".vecbasic")]]
 SEXP sexp_vecbasic_concentrate(SEXP dots) {
-    SEXP       out = PROTECT(sexp_vecbasic());
+    SEXP       out = PROTECT(sexp_vecbasic_s4());
     CVecBasic* vec = elt_vecbasic(out);
     
     for (R_xlen_t i = 0; i < Rf_length(dots); i++)
@@ -36,7 +36,7 @@ SEXP sexp_vecbasic_subset(SEXP ext, SEXP idx) {
         Rf_error("Internal? Index must be integer");
     
     CVecBasic* inv  = elt_vecbasic(ext);
-    SEXP       out  = PROTECT(sexp_vecbasic());
+    SEXP       out  = PROTECT(sexp_vecbasic_s4());
     CVecBasic* outv = elt_vecbasic(out);
     int*       ids  = INTEGER(idx);
     
@@ -54,7 +54,7 @@ SEXP sexp_vecbasic_subset(SEXP ext, SEXP idx) {
 
 // [[Rcpp::export(".vecbasic_get")]]
 SEXP sexp_vecbasic_get(SEXP ext, SEXP n) {
-    SEXP          out  = PROTECT(sexp_basic());
+    SEXP          out  = PROTECT(sexp_basic_s4());
     basic_struct* outv = elt_basic(out);
     
     // Currently vecbasic_get is implemented with vecbasic_subset, then extract the value

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -60,7 +60,7 @@ SEXP sexp_vecbasic_get(SEXP ext, SEXP n) {
     // Currently vecbasic_get is implemented with vecbasic_subset, then extract the value
     if (Rf_length(n) == 1) {
         SEXP res = PROTECT(sexp_vecbasic_subset(ext, n));
-        vecbasic_get(elt_vecbasic(res), 0, outv);
+        hold_exception(vecbasic_get(elt_vecbasic(res), 0, outv));
         UNPROTECT(1);
     }
     
@@ -78,7 +78,7 @@ SEXP sexp_vecbasic_get(SEXP ext, SEXP n) {
 static inline
 void _vecbasic_append_sexp(CVecBasic* self, SEXP ext) {
     if (is_basic(ext)) {
-        vecbasic_push_back(self, elt_basic(ext));
+        hold_exception(vecbasic_push_back(self, elt_basic(ext)));
         return;
     }
     if (is_vecbasic(ext)) {

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -10,7 +10,7 @@ extern "C" {
 
 // [[Rcpp::export(".vecbasic_length")]]
 size_t sexp_vecbasic_length(SEXP ext) {
-    CVecBasic*    vec = (CVecBasic*)    R_ExternalPtrAddr(ext);
+    CVecBasic* vec = elt_vecbasic(ext);
     size_t sz = vecbasic_size(vec);
     return sz;
 }
@@ -21,7 +21,7 @@ static inline void _vecbasic_append_sexp(CVecBasic* self, SEXP ext);
 // [[Rcpp::export(".vecbasic")]]
 SEXP sexp_vecbasic_concentrate(SEXP dots) {
     SEXP       out = PROTECT(sexp_vecbasic());
-    CVecBasic* vec = (CVecBasic*) R_ExternalPtrAddr(out);
+    CVecBasic* vec = elt_vecbasic(out);
     
     for (R_xlen_t i = 0; i < Rf_length(dots); i++)
         _vecbasic_append_sexp(vec, VECTOR_ELT(dots, i));
@@ -35,14 +35,14 @@ SEXP sexp_vecbasic_subset(SEXP ext, SEXP idx) {
     if (TYPEOF(idx) != INTSXP)
         Rf_error("Internal? Index must be integer");
     
-    CVecBasic* inv  = (CVecBasic*) R_ExternalPtrAddr(ext);
+    CVecBasic* inv  = elt_vecbasic(ext);
     SEXP       out  = PROTECT(sexp_vecbasic());
-    CVecBasic* outv = (CVecBasic*) R_ExternalPtrAddr(out);
+    CVecBasic* outv = elt_vecbasic(out);
     int*       ids  = INTEGER(idx);
     
     // Used as a temporarily value in the loop
     SEXP a = PROTECT(sexp_basic());
-    basic_struct* val = (basic_struct*) R_ExternalPtrAddr(a);
+    basic_struct* val = elt_basic(a);
     for (int i = 0; i < Rf_length(idx); i++) {
         hold_exception(vecbasic_get(inv, ids[i] - 1, val));
         hold_exception(vecbasic_push_back(outv, val));
@@ -55,12 +55,12 @@ SEXP sexp_vecbasic_subset(SEXP ext, SEXP idx) {
 // [[Rcpp::export(".vecbasic_get")]]
 SEXP sexp_vecbasic_get(SEXP ext, SEXP n) {
     SEXP          out  = PROTECT(sexp_basic());
-    basic_struct* outv = (basic_struct*) R_ExternalPtrAddr(out);
+    basic_struct* outv = elt_basic(out);
     
     // Currently vecbasic_get is implemented with vecbasic_subset, then extract the value
     if (Rf_length(n) == 1) {
         SEXP res = PROTECT(sexp_vecbasic_subset(ext, n));
-        vecbasic_get((CVecBasic*) R_ExternalPtrAddr(res), 0, outv);
+        vecbasic_get(elt_vecbasic(res), 0, outv);
         UNPROTECT(1);
     }
     
@@ -77,19 +77,16 @@ SEXP sexp_vecbasic_get(SEXP ext, SEXP n) {
 
 static inline
 void _vecbasic_append_sexp(CVecBasic* self, SEXP ext) {
-    if ((TYPEOF(ext) == EXTPTRSXP) &&
-        R_compute_identical(R_ExternalPtrTag(ext), Rf_mkString("basic_struct*"), 15)) {
-        
-        vecbasic_push_back(self, (basic_struct*) R_ExternalPtrAddr(ext));
+    if (is_basic(ext)) {
+        vecbasic_push_back(self, elt_basic(ext));
         return;
     }
-    if ((TYPEOF(ext) == EXTPTRSXP) &&
-        R_compute_identical(R_ExternalPtrTag(ext), Rf_mkString("CVecBasic*"), 15)) {
+    if (is_vecbasic(ext)) {
         
-        CVecBasic* toappend = (CVecBasic*) R_ExternalPtrAddr(ext);
+        CVecBasic* toappend = elt_vecbasic(ext);
         
         SEXP a = PROTECT(sexp_basic());
-        basic_struct* val = (basic_struct*) R_ExternalPtrAddr(a);
+        basic_struct* val = elt_basic(a);
         for (size_t i = 0; i < vecbasic_size(toappend); i++) {
             hold_exception(vecbasic_get(toappend, i, val));
             hold_exception(vecbasic_push_back(self, val));


### PR DESCRIPTION
- `is_basic` `is_vecbasic` `elt_basic` `elt_vecbasic`
Above functions working with both S4 and externalptr.

- `sexp_basic_s4` `sexp_vecbasic_s4`
Above two functions directly initialize S4 object for Basic or VecBasic in C.

I also apply these functions in `vector.cpp`.

cc. @irexyc 
