### PR TITLE
Change sed to be more robust on certain systems

### DIFF
--- a/configure
+++ b/configure
@@ -168,9 +168,9 @@ fi
 echo == generating src/Makevars
 
 cat src/Makevars.in | \
-    sed "s|@@@PKG_LIBS@@@|$PKG_LIBS_VALUE|g" | \
-    sed "s|@@@PKG_CPPFLAGS@@@|$PKG_CPPFLAGS_VALUE|g" | \
-    sed "s|@@@DO_UPSTREAM@@@|$DO_UPSTREAM|g" \
+    sed "s:@@@PKG_LIBS@@@:$PKG_LIBS_VALUE:g" | \
+    sed "s:@@@PKG_CPPFLAGS@@@:$PKG_CPPFLAGS_VALUE:g" | \
+    sed "s:@@@DO_UPSTREAM@@@:$DO_UPSTREAM:g" \
     > src/Makevars
 
 echo ====== configuring symengine R package DONE ======


### PR DESCRIPTION
Hi,

In rehat the package gives the following error:

```sh
== generating src/Makevars
sed: -e expression #1, char 80: unknown option to `s'
```

By changing the character from `|` to `:` it works on rehat too.