### PR TITLE
Fix CRAN check issue for Mac M1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -73,7 +73,12 @@ jobs:
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        run: |
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+          cat("####### 00check.log    ######################\n")
+          system2("cat", "check/*.Rcheck/00check.log")
+          cat("####### 00install.out  ######################\n")
+          system2("cat", "check/*.Rcheck/00install.out")
         shell: Rscript {0}
 
       - name: Upload check results

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: symengine
 Title: Interface to the 'SymEngine' Library
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: c(person("Jialin", "Ma", email="marlin@inventati.org", role = c("cre", "aut")),
              person("Isuru", "Fernando", email="isuruf@gmail.com", role = c("aut")),
              person("Xin", "Chen", email="xinchen.tju@gmail.com", role = c("aut")))

--- a/configure
+++ b/configure
@@ -68,6 +68,10 @@ fi
 CMAKE_C_FLAGS="$CPPFLAGS $CFLAGS"     ; echo set CMAKE_C_FLAGS="$CPPFLAGS $CFLAGS"    ; export CMAKE_C_FLAGS
 CMAKE_CXX_FLAGS="$CPPFLAGS $CXXFLAGS" ; echo set CMAKE_CXX_FLAGS="$CPPFLAGS $CXXFLAGS"; export CMAKE_CXX_FLAGS
 
+## Convert LDFLAGS/CPPFLAGS to CMAKE_LIBRARY_PATH/CMAKE_INCLUDE_PATH by removing the "-L"/"-I" prefix
+CMAKE_LIBRARY_PATH=`echo "$LDFLAGS"  | tr -s ' ' '\n' | grep '^-L' | sed 's/^-L//' | paste -sd ';' -` ; echo set CMAKE_LIBRARY_PATH="$CMAKE_LIBRARY_PATH"; export CMAKE_LIBRARY_PATH
+CMAKE_INCLUDE_PATH=`echo "$CPPFLAGS" | tr -s ' ' '\n' | grep '^-I' | sed 's/^-I//' | paste -sd ';' -` ; echo set CMAKE_INCLUDE_PATH="$CMAKE_INCLUDE_PATH"; export CMAKE_INCLUDE_PATH
+
 # LDFLAGS https://cmake.org/cmake/help/latest/envvar/LDFLAGS.html
 
 #if $CMAKE_BIN --find-package -DNAME=SymEngine -DCOMPILER_ID=GNU -DLANGUAGE=CXX -DMODE=LINK >/dev/null 2>/dev/null; then

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,0 @@
-
-## Version 0.1.5:
-
-Try to fix CRAN LTO checks.

--- a/tools/download_macos_cranlibs.sh
+++ b/tools/download_macos_cranlibs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Download CRAN MacOS binary dependencies from
+#   - https://mac.r-project.org/libs-4/ (x86_64/Intel)
+#   - https://mac.r-project.org/libs-arm64/ (arm64/M1)
+
+# This script is for local testing and CI (in future).
+
+set -eu
+
+# Util functions
+msg() {
+    echo >&2 -e "${1-}"
+}
+
+die() {
+    local msg=$1
+    local code=${2-1} # default exit status 1
+    msg "$msg"
+    exit "$code"
+}
+
+# Directory for placing the libraries
+OSARCH=`uname -m`
+rm -rf /tmp/r-cranlibs/${OSARCH} || true
+export CRANLIBS_ROOT=/tmp/r-cranlibs/${OSARCH}
+mkdir -p ${CRANLIBS_ROOT}
+
+download() {
+    curl -s "$1" | tar xzf - -C ${CRANLIBS_ROOT}/
+}
+
+if [ "$OSARCH" = "x86_64" ]; then
+    download https://mac.r-project.org/libs-4/gmp-6.2.1-darwin.17-x86_64.tar.gz
+    download https://mac.r-project.org/libs-4/mpfr-4.0.2-darwin.17-x86_64.tar.gz
+elif [ "$OSARCH" = "arm64" ]; then
+    download https://mac.r-project.org/libs-arm64/gmp-6.2.1-darwin.20-arm64.tar.gz
+    download https://mac.r-project.org/libs-arm64/mpfr-4.1.0-darwin.20-arm64.tar.gz
+else
+    die "Unimplemented for arch ${OSARCH}"
+fi
+
+msg "== Libraries have been downloaded to ${CRANLIBS_ROOT}"
+
+if [ "$OSARCH" = "x86_64" ]; then
+    prefix="/tmp/r-cranlibs/x86_64/usr/local"
+elif [ "$OSARCH" = "arm64" ]; then
+    prefix="/tmp/r-cranlibs/arm64/opt/R/arm64"
+else
+    die "Unexpected: Unimplemented for arch ${OSARCH}"
+fi


### PR DESCRIPTION
On Mac M1, cran building machine will install gmp and mpfr dependencies in a non-standard location: `/opt/R/arm64`. This is reflected in output from `R CMD config LDFLAGS` and `R CMD config CPPFLAGS`.

This PR try to infer and set `CMAKE_LIBRARY_PATH` and `CMAKE_INCLUDE_PATH` based on results from `R CMD config` to fix the building failure in CRAN.