### PR TITLE
Update bundled symengine library version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ inst/doc
 src/Makevars
 docs
 /src/upstream/
+/src/upstream.tar
 /tools/SYMENGINE_BUNDLED

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: symengine
 Title: Interface to the 'SymEngine' Library
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(person("Jialin", "Ma", email="marlin@inventati.org", role = c("cre", "aut")),
              person("Isuru", "Fernando", email="isuruf@gmail.com", role = c("aut")),
              person("Xin", "Chen", email="xinchen.tju@gmail.com", role = c("aut")))

--- a/tools/bundle_symengine_source.sh
+++ b/tools/bundle_symengine_source.sh
@@ -17,7 +17,7 @@ fi
 PKG_DIR=`pwd`
 
 SYMENGINE_REPO="symengine/symengine"
-SYMENGINE_COMMIT=148d4fa2aaa38afc92d4dfb203b00fdf71f3be2e
+SYMENGINE_COMMIT=ad84b9677e814e6ac328d7127da092d4d8722afe
 
 echo === Bundle source from commit: $SYMENGINE_COMMIT
 

--- a/tools/cran_comments/cran-comments_0.1.6.md
+++ b/tools/cran_comments/cran-comments_0.1.6.md
@@ -1,0 +1,9 @@
+
+Dear CRAN team,
+
+This version (0.1.6) fixes the build error on Mac M1 (arm64) machine.
+
+Unfortunately the check error with windows UCRT build has not been fixed with this submission.
+However I will try to tackle the issue in the coming weeks. But I don't want to delay this fix for Mac M1.
+
+- Jialin Ma

--- a/tools/cran_comments/cran-comments_0.2.1.md
+++ b/tools/cran_comments/cran-comments_0.2.1.md
@@ -1,0 +1,5 @@
+
+This version (0.2.0) fixes the build error on windows with R version 4.2+.
+It now uses Rtools42 to build the package so that it no longer needs to
+download dependencies of static libraries when building on Windows.
+


### PR DESCRIPTION
To fix the NOTE on `R CMD check`:

```
* checking line endings in C/C++/Fortran sources/headers ... NOTE
Found the following sources/headers not terminated with a newline:
  src/upstream/cmake/checkgmpxx.cpp
  src/upstream/symengine/polys/basic_conversions.cpp
  src/upstream/symengine/utilities/teuchos/Teuchos_TestForException.cpp
Some compilers warn on such files.

```